### PR TITLE
ci(GHA): Adds Node 18 to CI matrix

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        # Reduce at EOL - https://nodejs.org/en/about/releases/
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 18 became current 2022-04-19.
https://nodejs.org/en/about/releases/