### PR TITLE
ci(Renovate): Set minimumReleaseAge to 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
 	"schedule": "at any time",
 	"rebaseWhen": "conflicted",
 	"rangeStrategy": "replace",
+	"minimumReleaseAge": "3 days",
 	"major": {
 		"automerge": false,
 		"prConcurrentLimit": 3


### PR DESCRIPTION
Similar to pnpm's `minimumReleaseAge` setting.

https://pnpm.io/supply-chain-security
https://pnpm.io/settings#minimumreleaseage